### PR TITLE
Update action.yml to use node v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "The directory where the generated Markdown files will be saved"
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
"The following actions use a deprecated Node.js version and will be forced to run on node20: keiranlovett/rss-feed-to-markdown@main"

Normally I would suggest making a v2 branch for Node 20, but Github is forcing everything using < Node 20 to use Node 20 anyway, so this will just get rid of the warning.